### PR TITLE
Add authorization status for iOS

### DIFF
--- a/lib/src/apns_connector.dart
+++ b/lib/src/apns_connector.dart
@@ -20,6 +20,10 @@ class ApnsPushConnector extends PushConnector {
         'requestNotificationPermissions', iosSettings.toMap());
   }
 
+  void getAuthorizationStatus() {
+    _channel.invokeMethod('getAuthorizationStatus', []);
+  }
+
   final StreamController<IosNotificationSettings> _iosSettingsStreamController =
       StreamController<IosNotificationSettings>.broadcast();
 
@@ -53,6 +57,9 @@ class ApnsPushConnector extends PushConnector {
 
         isDisabledByUser.value = obj?.alert == false;
         return null;
+      case 'setAuthorizationStatus':
+        authorizationStatus.value = call.arguments;
+        return null;
       case 'onMessage':
         return _onMessage(call.arguments.cast<String, dynamic>());
       case 'onLaunch':
@@ -74,6 +81,8 @@ class ApnsPushConnector extends PushConnector {
 
   @override
   final isDisabledByUser = ValueNotifier(null);
+
+  final authorizationStatus = ValueNotifier<String>(null);
 
   @override
   final token = ValueNotifier<String>(null);


### PR DESCRIPTION
I found it useful to know the authorization status before calling `requestNotificationPermissions`, because in my case I wanted to display a warning to the user so that their chances of approving the notification permission request is higher. 

Thought it might be useful for other people as well. I can clean up the PR further if there is interest. (First time working with Swift so recommendations welcome as well.)