### PR TITLE
Fix onLaunch not working with closed app

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ if #available(iOS 10.0, *) {
 ```
 
 4. Add `flutter_apns` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
-5. Using `createPushConnector()` method, configure push service according to your needs. `PushConnector` closely resembles `FirebaseMessaging`, so Firebase samples may be useful during implementation.
+5. Using `createPushConnector()` method, configure push service according to your needs. `PushConnector` closely resembles `FirebaseMessaging`, so Firebase samples may be useful during implementation. You should create the connector as soon as possible to get the onLaunch callback working on closed app launch.
 ```dart
 import 'package:flutter_apns/apns.dart';
 

--- a/ios/Classes/FlutterApnsPlugin.swift
+++ b/ios/Classes/FlutterApnsPlugin.swift
@@ -35,6 +35,14 @@ func getFlutterError(_ error: Error) -> FlutterError {
             
         case "configure":
             UIApplication.shared.registerForRemoteNotifications()
+
+            // check for onLaunch notification *after* configure has been ran
+            if launchNotification != nil {
+                NSLog("configure launchNotification: %@", self.launchNotification ?? "nil")
+                channel.invokeMethod("onLaunch", arguments: self.launchNotification)
+                self.launchNotification = nil
+                return
+            }
             result(nil)
             
         case "unregister":
@@ -215,13 +223,6 @@ func getFlutterError(_ error: Error) -> FlutterError {
     }
     
     func onResume(userInfo: [AnyHashable: Any]) {
-        if let launchNotification = launchNotification {
-            NSLog("onResume launchNotification: %@", self.launchNotification ?? "nil")
-            channel.invokeMethod("onLaunch", arguments: userInfo)
-            self.launchNotification = nil
-            return
-        }
-        
         channel.invokeMethod("onResume", arguments: userInfo)
     }
 }

--- a/ios/Classes/FlutterApnsPlugin.swift
+++ b/ios/Classes/FlutterApnsPlugin.swift
@@ -149,8 +149,8 @@ func getFlutterError(_ error: Error) -> FlutterError {
     
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [AnyHashable : Any] = [:]) -> Bool {
         launchNotification = launchOptions[UIApplication.LaunchOptionsKey.remoteNotification] as? [String: Any]
-        NSLog("\nlaunchNotification %@", launchNotification ?? "nil")
-        
+        NSLog("\nlaunchNotification: %@", launchNotification ?? "nil")
+
         return true
     }
     
@@ -166,11 +166,6 @@ func getFlutterError(_ error: Error) -> FlutterError {
     
     public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         channel.invokeMethod("onToken", arguments: deviceToken.hexString)
-        
-        if launchNotification != nil {
-            channel.invokeMethod("onLaunch", arguments: launchNotification)
-            self.launchNotification = nil
-        }
     }
     
     
@@ -221,6 +216,7 @@ func getFlutterError(_ error: Error) -> FlutterError {
     
     func onResume(userInfo: [AnyHashable: Any]) {
         if let launchNotification = launchNotification {
+            NSLog("onResume launchNotification: %@", self.launchNotification ?? "nil")
             channel.invokeMethod("onLaunch", arguments: userInfo)
             self.launchNotification = nil
             return

--- a/ios/Classes/FlutterApnsPlugin.swift
+++ b/ios/Classes/FlutterApnsPlugin.swift
@@ -149,6 +149,8 @@ func getFlutterError(_ error: Error) -> FlutterError {
     
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [AnyHashable : Any] = [:]) -> Bool {
         launchNotification = launchOptions[UIApplication.LaunchOptionsKey.remoteNotification] as? [String: Any]
+        NSLog("\nlaunchNotification %@", launchNotification ?? "nil")
+        
         return true
     }
     
@@ -164,6 +166,11 @@ func getFlutterError(_ error: Error) -> FlutterError {
     
     public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         channel.invokeMethod("onToken", arguments: deviceToken.hexString)
+        
+        if launchNotification != nil {
+            channel.invokeMethod("onLaunch", arguments: launchNotification)
+            self.launchNotification = nil
+        }
     }
     
     

--- a/lib/src/connector.dart
+++ b/lib/src/connector.dart
@@ -17,6 +17,7 @@ abstract class PushConnector {
   String get providerType;
 
   /// Configures callbacks for supported message situations.
+  /// It should be called as soon as app is launch or you won't get the `onLaunch` callback
   void configure({
     /// iOS only: return true to display notification while app is in foreground
     MessageHandler onMessage,


### PR DESCRIPTION
Hello there!

I don't understand when the actual onLaunch implementation should trigger but I fixed it by checking if there is a notification when `didRegisterForRemoteNotificationsWithDeviceToken` is called.

Maybe there is a better place to put the onLaunch check but at least it works. 

