### PR TITLE
fix isDisabledByUser default value

### DIFF
--- a/flutter_apns/lib/src/connector.dart
+++ b/flutter_apns/lib/src/connector.dart
@@ -8,7 +8,7 @@ typedef Future<void> MessageHandler(RemoteMessage message);
 abstract class PushConnector {
   /// User declined to allow for push messages.
   /// initially nil
-  ValueNotifier<bool> get isDisabledByUser;
+  ValueNotifier<bool?> get isDisabledByUser;
 
   /// Value of registered token
   /// initially nil

--- a/flutter_apns/lib/src/firebase_connector.dart
+++ b/flutter_apns/lib/src/firebase_connector.dart
@@ -7,7 +7,7 @@ class FirebasePushConnector extends PushConnector {
   late final firebase = FirebaseMessaging.instance;
 
   @override
-  final isDisabledByUser = ValueNotifier(false);
+  final isDisabledByUser = ValueNotifier<bool?>(null);
 
   bool didInitialize = false;
 

--- a/flutter_apns_only/lib/flutter_apns_only.dart
+++ b/flutter_apns_only/lib/flutter_apns_only.dart
@@ -97,7 +97,7 @@ class ApnsPushConnectorOnly {
   /// Returning true will delay onMessage callback until user actually clicks on it
   WillPresentHandler? shouldPresent;
 
-  final isDisabledByUser = ValueNotifier(false);
+  final isDisabledByUser = ValueNotifier<bool?>(null);
 
   final authorizationStatus = ValueNotifier<String?>(null);
 


### PR DESCRIPTION
The default value of isDisabledByUser is not null. So it's not compatible with 1.1.0.

### 1.1.0
* merged https://github.com/mwaylabs/flutter-apns/pull/11 - make sure that you are handling isDisabledByUser == null