### PR TITLE
Ability to pass options when configure

### DIFF
--- a/flutter_apns/lib/src/apns_connector.dart
+++ b/flutter_apns/lib/src/apns_connector.dart
@@ -1,12 +1,13 @@
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_apns_only/flutter_apns_only.dart';
 export 'package:flutter_apns_only/flutter_apns_only.dart';
+import 'package:firebase_core/firebase_core.dart';
 
 import 'connector.dart';
 
 class ApnsPushConnector extends ApnsPushConnectorOnly implements PushConnector {
   @override
-  void configure({onMessage, onLaunch, onResume, onBackgroundMessage}) {
+  void configure({onMessage, onLaunch, onResume, onBackgroundMessage, options}) {
     ApnsMessageHandler? mapHandler(MessageHandler? input) {
       if (input == null) {
         return null;
@@ -19,7 +20,7 @@ class ApnsPushConnector extends ApnsPushConnectorOnly implements PushConnector {
       onMessage: mapHandler(onMessage),
       onLaunch: mapHandler(onLaunch),
       onResume: mapHandler(onResume),
-      onBackgroundMessage: mapHandler(onBackgroundMessage),
+      onBackgroundMessage: mapHandler(onBackgroundMessage)
     );
   }
 }

--- a/flutter_apns/lib/src/connector.dart
+++ b/flutter_apns/lib/src/connector.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
+import 'package:firebase_core/firebase_core.dart';
 
 /// Function signature for callbacks executed when push message is available;
 typedef Future<void> MessageHandler(RemoteMessage message);

--- a/flutter_apns/lib/src/connector.dart
+++ b/flutter_apns/lib/src/connector.dart
@@ -25,6 +25,7 @@ abstract class PushConnector {
     MessageHandler? onLaunch,
     MessageHandler? onResume,
     MessageHandler? onBackgroundMessage,
+    FirebaseOptions? options,
   });
 
   /// Prompts (if need) the user to enable push notifications.

--- a/flutter_apns/lib/src/firebase_connector.dart
+++ b/flutter_apns/lib/src/firebase_connector.dart
@@ -17,10 +17,11 @@ class FirebasePushConnector extends PushConnector {
     MessageHandler? onLaunch,
     MessageHandler? onResume,
     MessageHandler? onBackgroundMessage,
+    FirebaseOptions? options,
   }) async {
     if (!didInitialize) {
       await Firebase.initializeApp(
-        options: DefaultFirebaseOptions.currentPlatform,
+        options: options,
       );
       didInitialize = true;
     }

--- a/flutter_apns/lib/src/firebase_connector.dart
+++ b/flutter_apns/lib/src/firebase_connector.dart
@@ -19,7 +19,9 @@ class FirebasePushConnector extends PushConnector {
     MessageHandler? onBackgroundMessage,
   }) async {
     if (!didInitialize) {
-      await Firebase.initializeApp();
+      await Firebase.initializeApp(
+        options: DefaultFirebaseOptions.currentPlatform,
+      );
       didInitialize = true;
     }
 


### PR DESCRIPTION
It seems that latest version of firebase plugin won't create the `google-services.json` but instead it creates a `lib/firebase_options.dart` file and because of this the initialization is different.

https://firebase.flutter.dev/docs/overview

I added a `options` parameter to pass when calling `configure` so you can pass the options. So the initialization will look like this:

```
connector.configure(
  onLaunch: (data) => onPush('onLaunch', data),
  onResume: (data) => onPush('onResume', data),
  onMessage: (data) => onPush('onMessage', data),
  onBackgroundMessage: (data) => onPush('onBackgroundMessage', data),
  options: DefaultFirebaseOptions.currentPlatform,
);
```