### PR TITLE
Add option to respect async behavior from caller

### DIFF
--- a/flutter_apns/lib/src/apns_connector.dart
+++ b/flutter_apns/lib/src/apns_connector.dart
@@ -1,13 +1,12 @@
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_apns_only/flutter_apns_only.dart';
 export 'package:flutter_apns_only/flutter_apns_only.dart';
-import 'package:firebase_core/firebase_core.dart';
 
 import 'connector.dart';
 
 class ApnsPushConnector extends ApnsPushConnectorOnly implements PushConnector {
   @override
-  void configure({onMessage, onLaunch, onResume, onBackgroundMessage, options}) {
+  Future<void> configure({onMessage, onLaunch, onResume, onBackgroundMessage, options}) {
     ApnsMessageHandler? mapHandler(MessageHandler? input) {
       if (input == null) {
         return null;
@@ -17,10 +16,11 @@ class ApnsPushConnector extends ApnsPushConnectorOnly implements PushConnector {
     }
 
     configureApns(
-      onMessage: mapHandler(onMessage),
-      onLaunch: mapHandler(onLaunch),
-      onResume: mapHandler(onResume),
-      onBackgroundMessage: mapHandler(onBackgroundMessage)
-    );
+        onMessage: mapHandler(onMessage),
+        onLaunch: mapHandler(onLaunch),
+        onResume: mapHandler(onResume),
+        onBackgroundMessage: mapHandler(onBackgroundMessage));
+
+    return Future<void>.value();
   }
 }

--- a/flutter_apns/lib/src/connector.dart
+++ b/flutter_apns/lib/src/connector.dart
@@ -20,7 +20,7 @@ abstract class PushConnector {
 
   /// Configures callbacks for supported message situations.
   /// It should be called as soon as app is launch or you won't get the `onLaunch` callback
-  void configure({
+  Future<void> configure({
     /// iOS only: return true to display notification while app is in foreground
     MessageHandler? onMessage,
     MessageHandler? onLaunch,

--- a/flutter_apns/lib/src/firebase_connector.dart
+++ b/flutter_apns/lib/src/firebase_connector.dart
@@ -12,7 +12,7 @@ class FirebasePushConnector extends PushConnector {
   bool didInitialize = false;
 
   @override
-  void configure({
+  Future<void> configure({
     MessageHandler? onMessage,
     MessageHandler? onLaunch,
     MessageHandler? onResume,


### PR DESCRIPTION
Exceptions thrown by the asynchronous implementation of `configure` in the `FirebasePushConnector` cannot be caught by the caller the interface signature does not give any knowledge about a possible asynchronous behavior.

**Steps to reproduce**
+ Create an Android emulator without Google APIs
+ Add an exception handler around `configure`

**Expected behavior**
+ Exception `MISSING_INSTANCEID_SERVICE` is caught by the exception handler

**Actual behavior**
+ Exception is not caught by the exception handler

# Solution
Changed the method signature in the interface to return a `Future` in order to be awaited by the caller.

Background knowledge: https://dart.dev/codelabs/async-await#handling-errors