### PR TITLE
fix: badges not updated in foreground

### DIFF
--- a/flutter_apns_only/ios/Classes/FlutterApnsPlugin.swift
+++ b/flutter_apns_only/ios/Classes/FlutterApnsPlugin.swift
@@ -176,7 +176,6 @@ func getFlutterError(_ error: Error) -> FlutterError {
     
     public func applicationDidBecomeActive(_ application: UIApplication) {
         resumingFromBackground = false
-        UIApplication.shared.applicationIconBadgeNumber = -1;
     }
     
     public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
@@ -209,7 +208,7 @@ func getFlutterError(_ error: Error) -> FlutterError {
         channel.invokeMethod("willPresent", arguments: dict) { (result) in
             let shouldShow = (result as? Bool) ?? false
             if shouldShow {
-                completionHandler([.alert, .sound])
+                completionHandler([.alert, .sound, .badge])
             } else {
                 completionHandler([])
                 let userInfo = FlutterApnsSerialization.remoteMessageUserInfo(toDict: userInfo)


### PR DESCRIPTION
I can't get the foreground badges updated because they are not included in `UNNotificationPresentationOptions`, so I add `.badge` to it.

Further, I think the user could select what options should be made when it is foreground. :)

